### PR TITLE
add sbref to suffix dict

### DIFF
--- a/bids2nda/main.py
+++ b/bids2nda/main.py
@@ -130,6 +130,7 @@ def run(args):
 
     suffix_to_scan_type = {"dwi": "MR diffusion",
                            "bold": "fMRI",
+                           "sbref": "fMRI",
                            #""MR structural(MPRAGE)",
                            "T1w": "MR structural (T1)",
                            "PD": "MR structural (PD)",


### PR DESCRIPTION
Fixes error when running on multiband data containing SBRef images, identifying these as fMRI images.